### PR TITLE
Flatten

### DIFF
--- a/flatten.go
+++ b/flatten.go
@@ -1,0 +1,18 @@
+package multierror
+
+func Flatten(err error) error {
+	flatErr := new(Error)
+	flatten(err, flatErr)
+	return error(flatErr)
+}
+
+func flatten(err error, flatErr *Error) {
+	switch err := err.(type) {
+	case *Error:
+		for _, e := range err.Errors {
+			flatten(e, flatErr)
+		}
+	default:
+		flatErr.Errors = append(flatErr.Errors, err)
+	}
+}

--- a/flatten_test.go
+++ b/flatten_test.go
@@ -1,0 +1,39 @@
+package multierror
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestFlatten(t *testing.T) {
+	original := &Error{
+		Errors: []error{
+			errors.New("one"),
+			&Error{
+				Errors: []error{
+					errors.New("two"),
+					&Error{
+						Errors: []error{
+							errors.New("three"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	expected := strings.TrimSpace(`
+3 error(s) occurred:
+
+* one
+* two
+* three
+	`)
+	actual := fmt.Sprintf("%s", Flatten(original))
+
+	if expected != actual {
+		t.Fatalf("expected: %s, got: %s", expected, actual)
+	}
+}


### PR DESCRIPTION
Useful for cleaning up potentially nested multierrors before output.