### PR TITLE
Preserve nil value when no errors have occurred.

### DIFF
--- a/append.go
+++ b/append.go
@@ -1,5 +1,18 @@
 package multierror
 
+// removeNills preserves the non-nill elements
+// of a slice. This is a destructive operation
+// the contents of the original slice are modified.
+func removeNills(errs []error) []error {
+	view := errs[:0]
+	for _, err := range errs {
+		if err != nil {
+			view = append(view, err)
+		}
+	}
+	return view
+}
+
 // Append is a helper function that will append more errors
 // onto an Error in order to create a larger multi-error.
 //
@@ -7,6 +20,13 @@ package multierror
 // one. If any of the errs are multierr.Error, they will be flattened
 // one level into err.
 func Append(err error, errs ...error) *Error {
+
+	errs = removeNills(errs)
+	// Preserve nil value when no errors have occurred
+	if err == nil && len(errs) == 0 {
+		return nil
+	}
+
 	switch err := err.(type) {
 	case *Error:
 		// Typed nils can reach here, so initialize if we are nil

--- a/append_test.go
+++ b/append_test.go
@@ -5,6 +5,14 @@ import (
 	"testing"
 )
 
+func TestRemoveNills(t *testing.T) {
+	errs := []error{errors.New("foo"), nil, nil, errors.New("foo"), nil}
+	errs = removeNills(errs)
+	if len(errs) != 2 {
+		t.Fatalf("wrong len: %d", len(errs))
+	}
+}
+
 func TestAppend_Error(t *testing.T) {
 	original := &Error{
 		Errors: []error{errors.New("foo")},
@@ -44,6 +52,14 @@ func TestAppend_NilError(t *testing.T) {
 	result := Append(err, errors.New("bar"))
 	if len(result.Errors) != 1 {
 		t.Fatalf("wrong len: %d", len(result.Errors))
+	}
+}
+
+func TestAppend_NilNil(t *testing.T) {
+	var err error
+	result := Append(err, nil)
+	if result != nil {
+		t.Fatalf("non-nil errors: %s", result.GoString())
 	}
 }
 


### PR DESCRIPTION
This patch handles nil values when passed into the slice argument of Append(err error, errs ...error). nil values are filtered out and not included in the multierror. When the first argument
to Append is nil, and the second argument consists entirely of nil values, then return a nil value.

This patch allows the usage the following style.

```
var result error

result = multierror.Append(result, step1())
result = multierror.Append(result, step2())

return result
```

result will be nil if-and-only-if step1() and step2() both return nil.

I believe this change is backwards compatible. The old behavior when nil values were passed into the slice argument of Append() was to wrap the nil values inside error objects. If this change is not backwards compatible I can revise the patch to instead declare a new function `AppendNonNill(err error, errs ...error)`