### PR TITLE
Singular message for a single error

### DIFF
--- a/flatten_test.go
+++ b/flatten_test.go
@@ -26,7 +26,7 @@ func TestFlatten(t *testing.T) {
 	}
 
 	expected := strings.TrimSpace(`
-3 error(s) occurred:
+3 errors occurred:
 
 * one
 * two

--- a/format.go
+++ b/format.go
@@ -12,12 +12,16 @@ type ErrorFormatFunc func([]error) string
 // ListFormatFunc is a basic formatter that outputs the number of errors
 // that occurred along with a bullet point list of the errors.
 func ListFormatFunc(es []error) string {
+	if len(es) == 1 {
+		return fmt.Sprintf("1 error occurred:\n\n* %s", es[0])
+	}
+
 	points := make([]string, len(es))
 	for i, err := range es {
 		points[i] = fmt.Sprintf("* %s", err)
 	}
 
 	return fmt.Sprintf(
-		"%d error(s) occurred:\n\n%s",
+		"%d errors occurred:\n\n%s",
 		len(es), strings.Join(points, "\n"))
 }

--- a/format_test.go
+++ b/format_test.go
@@ -5,8 +5,23 @@ import (
 	"testing"
 )
 
-func TestListFormatFunc(t *testing.T) {
-	expected := `2 error(s) occurred:
+func TestListFormatFuncSingle(t *testing.T) {
+	expected := `1 error occurred:
+
+* foo`
+
+	errors := []error{
+		errors.New("foo"),
+	}
+
+	actual := ListFormatFunc(errors)
+	if actual != expected {
+		t.Fatalf("bad: %#v", actual)
+	}
+}
+
+func TestListFormatFuncMultiple(t *testing.T) {
+	expected := `2 errors occurred:
 
 * foo
 * bar`

--- a/multierror_test.go
+++ b/multierror_test.go
@@ -27,7 +27,7 @@ func TestErrorError_custom(t *testing.T) {
 }
 
 func TestErrorError_default(t *testing.T) {
-	expected := `2 error(s) occurred:
+	expected := `2 errors occurred:
 
 * foo
 * bar`


### PR DESCRIPTION
### Before

```
2 error(s) occurred:

* foo
* bar
```

```
1 error(s) occurred:

* foo
```

### After

```
2 errors occurred:

* foo
* bar
```

```
1 error occurred:

* foo
```