### PR TITLE
append should only append if error to append is non-nil

### DIFF
--- a/append.go
+++ b/append.go
@@ -18,9 +18,13 @@ func Append(err error, errs ...error) *Error {
 		for _, e := range errs {
 			switch e := e.(type) {
 			case *Error:
-				err.Errors = append(err.Errors, e.Errors...)
+				if e != nil {
+					err.Errors = append(err.Errors, e.Errors...)
+				}
 			default:
-				err.Errors = append(err.Errors, e)
+				if e != nil {
+					err.Errors = append(err.Errors, e)
+				}
 			}
 		}
 

--- a/append_test.go
+++ b/append_test.go
@@ -47,6 +47,24 @@ func TestAppend_NilError(t *testing.T) {
 	}
 }
 
+func TestAppend_NilErrorArg(t *testing.T) {
+	var err error
+	var nilErr *Error
+	result := Append(err, nilErr)
+	if len(result.Errors) != 0 {
+		t.Fatalf("wrong len: %d", len(result.Errors))
+	}
+}
+
+func TestAppend_NilErrorIfaceArg(t *testing.T) {
+	var err error
+	var nilErr error
+	result := Append(err, nilErr)
+	if len(result.Errors) != 0 {
+		t.Fatalf("wrong len: %d", len(result.Errors))
+	}
+}
+
 func TestAppend_NonError(t *testing.T) {
 	original := errors.New("foo")
 	result := Append(original, errors.New("bar"))


### PR DESCRIPTION
If a nil error was given to `Append` as an argument, a crash would occur. This guards against that.