### PR TITLE
Allow non error type for the first argument of Append

### DIFF
--- a/append.go
+++ b/append.go
@@ -1,12 +1,16 @@
 package multierror
 
+import (
+	"fmt"
+)
+
 // Append is a helper function that will append more errors
 // onto an Error in order to create a larger multi-error.
 //
 // If err is not a multierror.Error, then it will be turned into
 // one. If any of the errs are multierr.Error, they will be flattened
 // one level into err.
-func Append(err error, errs ...error) *Error {
+func Append(err interface{}, errs ...error) *Error {
 	switch err := err.(type) {
 	case *Error:
 		// Typed nils can reach here, so initialize if we are nil
@@ -32,7 +36,12 @@ func Append(err error, errs ...error) *Error {
 	default:
 		newErrs := make([]error, 0, len(errs)+1)
 		if err != nil {
-			newErrs = append(newErrs, err)
+			switch err := err.(type) {
+			case error:
+				newErrs = append(newErrs, err)
+			default:
+				newErrs = append(newErrs, fmt.Errorf("%v", err))
+			}
 		}
 		newErrs = append(newErrs, errs...)
 

--- a/append_test.go
+++ b/append_test.go
@@ -80,3 +80,10 @@ func TestAppend_NonError_Error(t *testing.T) {
 		t.Fatalf("wrong len: %d", len(result.Errors))
 	}
 }
+
+func TestAppend_NonErrorIface(t *testing.T) {
+	result := Append("foo", errors.New("bar"))
+	if len(result.Errors) != 2 {
+		t.Fatalf("wrong len: %d", len(result.Errors))
+	}
+}


### PR DESCRIPTION
This will have more convenience when we want to return a new simple error from a function that aggregated with the cause. Something like this:

```go
func foo() error {
	if err := bar(); err != nil {
		return multierror.Append("failed to bar", err)
	}
}
```