### PR TITLE
Allow marshalling a multi-error

### DIFF
--- a/multierror_test.go
+++ b/multierror_test.go
@@ -1,6 +1,7 @@
 package multierror
 
 import (
+	"encoding/json"
 	"errors"
 	"reflect"
 	"testing"
@@ -66,5 +67,35 @@ func TestErrorWrappedErrors(t *testing.T) {
 	multi := &Error{Errors: errors}
 	if !reflect.DeepEqual(multi.Errors, multi.WrappedErrors()) {
 		t.Fatalf("bad: %s", multi.WrappedErrors())
+	}
+}
+
+func TestErrorJson(t *testing.T) {
+	errors := []error{
+		errors.New("foo"),
+		errors.New("bar"),
+	}
+
+	multi := &Error{Errors: errors}
+
+	b, err := json.Marshal(multi)
+	if err != nil {
+		t.Fatalf("bad: %#v", err)
+	}
+
+	actual := `{"errors":["foo","bar"]}`
+
+	if string(b) != actual {
+		t.Fatalf("bad: %#v != %#v", string(b), actual)
+	}
+
+	rebuilt := &Error{}
+	err = json.Unmarshal(b, &rebuilt)
+	if err != nil {
+		t.Fatalf("bad: %#v", err)
+	}
+
+	if !reflect.DeepEqual(rebuilt, multi) {
+		t.Fatalf("bad: %#v != %#v", rebuilt, multi)
 	}
 }


### PR DESCRIPTION
Without this change any objects containing a multierror will fail to
Marshal, though most objects that implement the Error() interface
are safe (albeit not useful) to convert to JSON.

This pull request goes one step further and tries to make the JSON
output somewhat useful, and defines a way to reconstruct a
multierror that looks superficially similar to the original when
Unmarshalled again.