### PR TITLE
Update error output to be more readable

### DIFF
--- a/flatten_test.go
+++ b/flatten_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"strings"
 	"testing"
 )
 
@@ -25,13 +24,12 @@ func TestFlatten(t *testing.T) {
 		},
 	}
 
-	expected := strings.TrimSpace(`
-3 errors occurred:
+	expected := `3 errors occurred:
+	* one
+	* two
+	* three
 
-* one
-* two
-* three
-	`)
+`
 	actual := fmt.Sprintf("%s", Flatten(original))
 
 	if expected != actual {

--- a/format.go
+++ b/format.go
@@ -13,7 +13,7 @@ type ErrorFormatFunc func([]error) string
 // that occurred along with a bullet point list of the errors.
 func ListFormatFunc(es []error) string {
 	if len(es) == 1 {
-		return fmt.Sprintf("1 error occurred:\n\n* %s", es[0])
+		return fmt.Sprintf("1 error occurred:\n\t* %s\n\n", es[0])
 	}
 
 	points := make([]string, len(es))
@@ -22,6 +22,6 @@ func ListFormatFunc(es []error) string {
 	}
 
 	return fmt.Sprintf(
-		"%d errors occurred:\n\n%s",
-		len(es), strings.Join(points, "\n"))
+		"%d errors occurred:\n\t%s\n\n",
+		len(es), strings.Join(points, "\n\t"))
 }

--- a/format_test.go
+++ b/format_test.go
@@ -7,8 +7,9 @@ import (
 
 func TestListFormatFuncSingle(t *testing.T) {
 	expected := `1 error occurred:
+	* foo
 
-* foo`
+`
 
 	errors := []error{
 		errors.New("foo"),
@@ -22,9 +23,10 @@ func TestListFormatFuncSingle(t *testing.T) {
 
 func TestListFormatFuncMultiple(t *testing.T) {
 	expected := `2 errors occurred:
+	* foo
+	* bar
 
-* foo
-* bar`
+`
 
 	errors := []error{
 		errors.New("foo"),

--- a/multierror_test.go
+++ b/multierror_test.go
@@ -28,9 +28,10 @@ func TestErrorError_custom(t *testing.T) {
 
 func TestErrorError_default(t *testing.T) {
 	expected := `2 errors occurred:
+	* foo
+	* bar
 
-* foo
-* bar`
+`
 
 	errors := []error{
 		errors.New("foo"),


### PR DESCRIPTION
* Don't space out the error but append the next one
* During a test, type the expected result instead of parsing it

Current error output looks like:
```
Error applying plan:

3 error(s) occurred:

* azurerm_network_interface.machine1: 1 error(s) occurred:

* azurerm_network_interface.machine1: <some error string goes here>
* azurerm_network_interface.machine1: <some error string goes here>
* azurerm_network_interface.machine2: 1 error(s) occurred:

* azurerm_network_interface.machine: <some error string goes here>
```
This changes it to be:
```
Error applying plan:

3 error(s) occurred:
* azurerm_network_interface.machine1: 2 error(s) occurred:
	* azurerm_network_interface.machine1: <some error string goes here>
	* azurerm_network_interface.machine1: <some error string goes here>

* azurerm_network_interface.machine2: 1 error(s) occurred:
	* azurerm_network_interface.machine2: <some error string goes here>

```
Which imho makes things more readable.