### PR TITLE
Implement sort interface for error messages

### DIFF
--- a/sort.go
+++ b/sort.go
@@ -1,0 +1,16 @@
+package multierror
+
+// Len implements sort.Interface function for length
+func (err Error) Len() int {
+	return len(err.Errors)
+}
+
+// Swap implements sort.Interface function for swapping elements
+func (err Error) Swap(i, j int) {
+	err.Errors[i], err.Errors[j] = err.Errors[j], err.Errors[i]
+}
+
+// Less implements sort.Interface function for determining order
+func (err Error) Less(i, j int) bool {
+	return err.Errors[i].Error() < err.Errors[j].Error()
+}

--- a/sort_test.go
+++ b/sort_test.go
@@ -1,0 +1,52 @@
+package multierror
+
+import (
+	"errors"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestSortSingle(t *testing.T) {
+	errFoo := errors.New("foo")
+
+	expected := []error{
+		errFoo,
+	}
+
+	err := &Error{
+		Errors: []error{
+			errFoo,
+		},
+	}
+
+	sort.Sort(err)
+	if !reflect.DeepEqual(err.Errors, expected) {
+		t.Fatalf("bad: %#v", err)
+	}
+}
+
+func TestSortMultiple(t *testing.T) {
+	errBar := errors.New("bar")
+	errBaz := errors.New("baz")
+	errFoo := errors.New("foo")
+
+	expected := []error{
+		errBar,
+		errBaz,
+		errFoo,
+	}
+
+	err := &Error{
+		Errors: []error{
+			errFoo,
+			errBar,
+			errBaz,
+		},
+	}
+
+	sort.Sort(err)
+	if !reflect.DeepEqual(err.Errors, expected) {
+		t.Fatalf("bad: %#v", err)
+	}
+}


### PR DESCRIPTION
When implementing a large amount of messaging, it can be very helpful to be able to sort the errors before printing them out.

Previously with errors appended from looping through a map, it can return something like the following:

```
11 error(s) occurred:

		* expected SNS topic attribute "ApplicationSuccessFeedbackRoleArn" to match "^arn:aws:iam::[0-9]{12}:role/sns-delivery-status-role-", received: ""
		* expected SNS topic attribute "HTTPSuccessFeedbackSampleRate" to match "^80$", received: ""
		* expected SNS topic attribute "LambdaSuccessFeedbackSampleRate" to match "^90$", received: ""
		* expected SNS topic attribute "LambdaSuccessFeedbackRoleArn" to match "^arn:aws:iam::[0-9]{12}:role/sns-delivery-status-role-", received: ""
		* expected SNS topic attribute "SQSFailureFeedbackRoleArn" to match "^arn:aws:iam::[0-9]{12}:role/sns-delivery-status-role-", received: ""
		* expected SNS topic attribute "ApplicationSuccessFeedbackSampleRate" to match "^100$", received: ""
		* expected SNS topic attribute "ApplicationFailureFeedbackRoleArn" to match "^arn:aws:iam::[0-9]{12}:role/sns-delivery-status-role-", received: ""
		* expected SNS topic attribute "HTTPSuccessFeedbackRoleArn" to match "^arn:aws:iam::[0-9]{12}:role/sns-delivery-status-role-", received: ""
		* expected SNS topic attribute "HTTPFailureFeedbackRoleArn" to match "^arn:aws:iam::[0-9]{12}:role/sns-delivery-status-role-", received: ""
		* expected SNS topic attribute "LambdaFailureFeedbackRoleArn" to match "^arn:aws:iam::[0-9]{12}:role/sns-delivery-status-role-", received: ""
		* expected SNS topic attribute "SQSSuccessFeedbackRoleArn" to match "^arn:aws:iam::[0-9]{12}:role/sns-delivery-status-role-", received: ""
```

Now it should be possible to `sort.Sort(errors)` before formatting so it returns:

```
11 error(s) occurred:

		* expected SNS topic attribute "ApplicationFailureFeedbackRoleArn" to match "^arn:aws:iam::[0-9]{12}:role/sns-delivery-status-role-", received: ""
		* expected SNS topic attribute "ApplicationSuccessFeedbackRoleArn" to match "^arn:aws:iam::[0-9]{12}:role/sns-delivery-status-role-", received: ""
		* expected SNS topic attribute "ApplicationSuccessFeedbackSampleRate" to match "^100$", received: ""
		* expected SNS topic attribute "HTTPFailureFeedbackRoleArn" to match "^arn:aws:iam::[0-9]{12}:role/sns-delivery-status-role-", received: ""
		* expected SNS topic attribute "HTTPSuccessFeedbackRoleArn" to match "^arn:aws:iam::[0-9]{12}:role/sns-delivery-status-role-", received: ""
		* expected SNS topic attribute "HTTPSuccessFeedbackSampleRate" to match "^80$", received: ""
		* expected SNS topic attribute "LambdaFailureFeedbackRoleArn" to match "^arn:aws:iam::[0-9]{12}:role/sns-delivery-status-role-", received: ""
		* expected SNS topic attribute "LambdaSuccessFeedbackRoleArn" to match "^arn:aws:iam::[0-9]{12}:role/sns-delivery-status-role-", received: ""
		* expected SNS topic attribute "LambdaSuccessFeedbackSampleRate" to match "^90$", received: ""
		* expected SNS topic attribute "SQSFailureFeedbackRoleArn" to match "^arn:aws:iam::[0-9]{12}:role/sns-delivery-status-role-", received: ""
		* expected SNS topic attribute "SQSSuccessFeedbackRoleArn" to match "^arn:aws:iam::[0-9]{12}:role/sns-delivery-status-role-", received: ""
```

We could take this further and implement a `SortedListFormatFunc` or augment the existing `ListFormatFunc` to automatically sort as well. 