### PR TITLE
use go 1.13.x to build go-multierror

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ sudo: false
 language: go
 
 go:
-  - 1.x
+  - 1.13.x
 
 branches:
   only:
     - master
 
-script: env GO111MODULE=on make test testrace
+script: make test testrace

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/hashicorp/go-multierror
 
 require github.com/hashicorp/errwrap v1.0.0
+
+go 1.13

--- a/prefix_test.go
+++ b/prefix_test.go
@@ -27,6 +27,9 @@ func TestPrefix_NilError(t *testing.T) {
 func TestPrefix_NonError(t *testing.T) {
 	original := errors.New("foo")
 	result := Prefix(original, "bar")
+	if result == nil {
+		t.Fatal("error result was nil")
+	}
 	if result.Error() != "bar foo" {
 		t.Fatalf("bad: %s", result)
 	}


### PR DESCRIPTION
The go `1.x` in the travis YAML pulls down the latest go release. Thought it'd be better to up the specificity by a notch and update the env vars/ Makefiles accordingly.