### PR TITLE
add sync/errgroup like functionality

### DIFF
--- a/group.go
+++ b/group.go
@@ -1,0 +1,38 @@
+package multierror
+
+import "sync"
+
+// Group is a collection of goroutines which return errors that need to be
+// coalesced.
+type Group struct {
+	mutex sync.Mutex
+	err   *Error
+	wg    sync.WaitGroup
+}
+
+// Go calls the given function in a new goroutine.
+//
+// If the function returns an error it is added to the group multierror which
+// is returned by Wait.
+func (g *Group) Go(f func() error) {
+	g.wg.Add(1)
+
+	go func() {
+		defer g.wg.Done()
+
+		if err := f(); err != nil {
+			g.mutex.Lock()
+			g.err = Append(g.err, err)
+			g.mutex.Unlock()
+		}
+	}()
+}
+
+// Wait blocks until all function calls from the Go method have returned, then
+// returns the multierror.
+func (g *Group) Wait() *Error {
+	g.wg.Wait()
+	g.mutex.Lock()
+	defer g.mutex.Unlock()
+	return g.err
+}

--- a/group_test.go
+++ b/group_test.go
@@ -1,0 +1,44 @@
+package multierror
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestGroup(t *testing.T) {
+	err1 := errors.New("group_test: 1")
+	err2 := errors.New("group_test: 2")
+
+	cases := []struct {
+		errs      []error
+		nilResult bool
+	}{
+		{errs: []error{}, nilResult: true},
+		{errs: []error{nil}, nilResult: true},
+		{errs: []error{err1}},
+		{errs: []error{err1, nil}},
+		{errs: []error{err1, nil, err2}},
+	}
+
+	for _, tc := range cases {
+		var g Group
+
+		for _, err := range tc.errs {
+			err := err
+			g.Go(func() error { return err })
+
+		}
+
+		gErr := g.Wait()
+		if gErr != nil {
+			for i := range tc.errs {
+				if tc.errs[i] != nil && !strings.Contains(gErr.Error(), tc.errs[i].Error()) {
+					t.Fatalf("expected error to contain %q, actual: %v", tc.errs[i].Error(), gErr)
+				}
+			}
+		} else if !tc.nilResult {
+			t.Fatalf("Group.Wait() should not have returned nil for errs: %v", tc.errs)
+		}
+	}
+}


### PR DESCRIPTION
A common pattern used in Nomad is collecting errors from a set of goroutines and combining them with multierror. This was inspired by the [sync/errgroup](https://godoc.org/golang.org/x/sync/errgroup) package, but instead of returning the first error, returns all errors combined with `Append`.

