### PR TITLE
Format nested multi-line errors neatly

### DIFF
--- a/format.go
+++ b/format.go
@@ -13,15 +13,22 @@ type ErrorFormatFunc func([]error) string
 // that occurred along with a bullet point list of the errors.
 func ListFormatFunc(es []error) string {
 	if len(es) == 1 {
-		return fmt.Sprintf("1 error occurred:\n\t* %s\n\n", es[0])
+		text := formatMultiLine(es[0])
+		return fmt.Sprintf("1 error occurred:\n\t* %s\n\n", text)
 	}
 
 	points := make([]string, len(es))
 	for i, err := range es {
-		points[i] = fmt.Sprintf("* %s", err)
+		text := formatMultiLine(err)
+		points[i] = fmt.Sprintf("* %s", text)
 	}
 
 	return fmt.Sprintf(
 		"%d errors occurred:\n\t%s\n\n",
 		len(es), strings.Join(points, "\n\t"))
+}
+
+func formatMultiLine(err error) string {
+	lines := strings.Split(err.Error(), "\n")
+	return strings.Join(lines, "\n\t  ")
 }

--- a/format_test.go
+++ b/format_test.go
@@ -21,6 +21,23 @@ func TestListFormatFuncSingle(t *testing.T) {
 	}
 }
 
+func TestListFormatFuncSingleMultiLine(t *testing.T) {
+	expected := `1 error occurred:
+	* foo
+	  bar
+
+`
+
+	errors := []error{
+		errors.New("foo\nbar"),
+	}
+
+	actual := ListFormatFunc(errors)
+	if actual != expected {
+		t.Fatalf("bad: %#v", actual)
+	}
+}
+
 func TestListFormatFuncMultiple(t *testing.T) {
 	expected := `2 errors occurred:
 	* foo
@@ -31,6 +48,26 @@ func TestListFormatFuncMultiple(t *testing.T) {
 	errors := []error{
 		errors.New("foo"),
 		errors.New("bar"),
+	}
+
+	actual := ListFormatFunc(errors)
+	if actual != expected {
+		t.Fatalf("bad: %#v", actual)
+	}
+}
+
+func TestListFormatFuncMultipleMultiLine(t *testing.T) {
+	expected := `2 errors occurred:
+	* foo
+	  qux
+	* bar
+	  alp
+
+`
+
+	errors := []error{
+		errors.New("foo\nqux"),
+		errors.New("bar\nalp"),
 	}
 
 	actual := ListFormatFunc(errors)


### PR DESCRIPTION
This makes the default formatter function robust against errors which have nested `\n` characters.

The overwhelmingly common case where an error is just one line is **unaffected**, so I presume this is backwards compatible in all cases where the current behavior is correct and desired.

I think this belongs in the default formatter rather than users having to plug it in because without this, any code that gives you an `error` in string form might have already "smudged" error information into ambiguous or hard-to-read form if that code used multierror and didn't proactively defend against the possibility of multi-line errors.