### PR TITLE
Added Suffix to mirror Prefix

### DIFF
--- a/suffix.go
+++ b/suffix.go
@@ -1,0 +1,37 @@
+package multierror
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/errwrap"
+)
+
+// Suffix is a helper function that will suffix some text
+// to the given error. If the error is a multierror.Error, then
+// it will be suffixed to each wrapped error.
+//
+// This is useful when Prefix would make the root error
+// hard to read by putting too much text in front of it.
+func Suffix(err error, suffix string) error {
+	if err == nil {
+		return nil
+	}
+
+	format := fmt.Sprintf("{{err}} %s", suffix)
+	switch err := err.(type) {
+	case *Error:
+		// Typed nils can reach here, so initialize if we are nil
+		if err == nil {
+			err = new(Error)
+		}
+
+		// Wrap each of the errors
+		for i, e := range err.Errors {
+			err.Errors[i] = errwrap.Wrapf(format, e)
+		}
+
+		return err
+	default:
+		return errwrap.Wrapf(format, err)
+	}
+}

--- a/suffix_test.go
+++ b/suffix_test.go
@@ -1,0 +1,33 @@
+package multierror
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestSuffix_Error(t *testing.T) {
+	original := &Error{
+		Errors: []error{errors.New("foo")},
+	}
+
+	result := Suffix(original, "bar")
+	if result.(*Error).Errors[0].Error() != "foo bar" {
+		t.Fatalf("bad: %s", result)
+	}
+}
+
+func TestSuffix_NilError(t *testing.T) {
+	var err error
+	result := Suffix(err, "bar")
+	if result != nil {
+		t.Fatalf("bad: %#v", result)
+	}
+}
+
+func TestSuffix_NonError(t *testing.T) {
+	original := errors.New("foo")
+	result := Suffix(original, "bar")
+	if result.Error() != "foo bar" {
+		t.Fatalf("bad: %s", result)
+	}
+}


### PR DESCRIPTION
The other week I wanted to attach some information to all errors in a multierror using `multierror.Prefix` but also didn't want to take visual focus off of the actual errors by having them behind the (rather long) context/scope information that I wanted to attach.

Maybe others have the same usecase, so here you go.

