### PR TITLE
Defer formatting when only one error is returned

### DIFF
--- a/format.go
+++ b/format.go
@@ -14,7 +14,8 @@ type ErrorFormatFunc func([]error) string
 // If only one error is within the errror slice, the error is returned unformatted
 func ListFormatFunc(es []error) string {
 	if len(es) == 1 {
-		return fmt.Sprintf("%s", es[0])
+		// Formatting should be deferred to the single error present
+		return es[0].Error()
 	}
 
 	points := make([]string, len(es))

--- a/format.go
+++ b/format.go
@@ -11,9 +11,10 @@ type ErrorFormatFunc func([]error) string
 
 // ListFormatFunc is a basic formatter that outputs the number of errors
 // that occurred along with a bullet point list of the errors.
+// If only one error is within the errror slice, the error is returned unformatted
 func ListFormatFunc(es []error) string {
 	if len(es) == 1 {
-		return fmt.Sprintf("1 error occurred:\n\t* %s\n\n", es[0])
+		return fmt.Sprintf("%s", es[0])
 	}
 
 	points := make([]string, len(es))

--- a/format.go
+++ b/format.go
@@ -11,7 +11,7 @@ type ErrorFormatFunc func([]error) string
 
 // ListFormatFunc is a basic formatter that outputs the number of errors
 // that occurred along with a bullet point list of the errors.
-/
+//
 // If only one error is within the errror slice,
 // the formatting should be deferred to the one and only error present
 func ListFormatFunc(es []error) string {

--- a/format.go
+++ b/format.go
@@ -11,7 +11,9 @@ type ErrorFormatFunc func([]error) string
 
 // ListFormatFunc is a basic formatter that outputs the number of errors
 // that occurred along with a bullet point list of the errors.
-// If only one error is within the errror slice, the error is returned unformatted
+/
+// If only one error is within the errror slice,
+// the formatting should be deferred to the one and only error present
 func ListFormatFunc(es []error) string {
 	if len(es) == 1 {
 		// Formatting should be deferred to the single error present

--- a/format_test.go
+++ b/format_test.go
@@ -6,10 +6,7 @@ import (
 )
 
 func TestListFormatFuncSingle(t *testing.T) {
-	expected := `1 error occurred:
-	* foo
-
-`
+	expected := `foo`
 
 	errors := []error{
 		errors.New("foo"),

--- a/format_test.go
+++ b/format_test.go
@@ -6,16 +6,33 @@ import (
 )
 
 func TestListFormatFuncSingle(t *testing.T) {
-	expected := `foo`
+	t.Run("Flat", func(t *testing.T) {
+		expected := `foo`
 
-	errors := []error{
-		errors.New("foo"),
-	}
+		errors := []error{
+			errors.New("foo"),
+		}
 
-	actual := ListFormatFunc(errors)
-	if actual != expected {
-		t.Fatalf("bad: %#v", actual)
-	}
+		actual := ListFormatFunc(errors)
+		if actual != expected {
+			t.Fatalf("bad: %#v", actual)
+		}
+	})
+
+	t.Run("Nested", func(t *testing.T) {
+		expected := `foo`
+
+		nestedErrors := &Error{
+			Errors: []error{
+				&Error{Errors: []error{errors.New("foo")}},
+			},
+		}
+
+		actual := ListFormatFunc(nestedErrors.Errors)
+		if actual != expected {
+			t.Fatalf("bad: %#v", actual)
+		}
+	})
 }
 
 func TestListFormatFuncMultiple(t *testing.T) {


### PR DESCRIPTION
* Testing for 1 error in unit tests and emitting only one error makes the `\n\t*` prepend impractical  and noisy. 

* There should be no need to do any multiple error logic until more than one error is present.

* When `multierror.Error.Error()` is called with `len(multierror.Error.Errors) == 1`, the formatting should be _deferred_ (gracefully decompose) to the one and only error present: `multierror.Error[0].Error()`