### PR TITLE
fix subtle interface bug on Group.Wait()

### DIFF
--- a/group.go
+++ b/group.go
@@ -30,9 +30,12 @@ func (g *Group) Go(f func() error) {
 
 // Wait blocks until all function calls from the Go method have returned, then
 // returns the multierror.
-func (g *Group) Wait() *Error {
+func (g *Group) Wait() error {
 	g.wg.Wait()
 	g.mutex.Lock()
 	defer g.mutex.Unlock()
-	return g.err
+	if g.err != nil {
+		return g.err
+	}
+	return nil
 }

--- a/group_test.go
+++ b/group_test.go
@@ -30,8 +30,11 @@ func TestGroup(t *testing.T) {
 
 		}
 
-		gErr := g.Wait()
+		var gErr error = g.Wait()
 		if gErr != nil {
+			if tc.nilResult {
+				t.Fatalf("Group.Wait() should have returned nil for errors")
+			}
 			for i := range tc.errs {
 				if tc.errs[i] != nil && !strings.Contains(gErr.Error(), tc.errs[i].Error()) {
 					t.Fatalf("expected error to contain %q, actual: %v", tc.errs[i].Error(), gErr)


### PR DESCRIPTION
Returning the concrete type `*Error` causes any assignments to an `error` type to result in a non-nil value, since the `error` interface would actually have `(*Error, nil)` rather than `(nil, nil)`. This matches the [sync/errgroup](https://godoc.org/golang.org/x/sync/errgroup) interface.

cc: @nickethier 