### PR TITLE
Update Append docs with nil error handling

### DIFF
--- a/append.go
+++ b/append.go
@@ -6,6 +6,8 @@ package multierror
 // If err is not a multierror.Error, then it will be turned into
 // one. If any of the errs are multierr.Error, they will be flattened
 // one level into err.
+// Any nil errors within errs will be ignored. If err is nil, a new
+// *Error will be returned.
 func Append(err error, errs ...error) *Error {
 	switch err := err.(type) {
 	case *Error:


### PR DESCRIPTION
Updated godocs to reflect that a nil error is ignored by `Append`.
Docs related to: https://github.com/hashicorp/go-multierror/issues/12