### PR TITLE
Return the stdlib error interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,26 @@ you're on an older version of go:
 /go/src/github.com/hashicorp/go-multierror/multierror.go:112:9: undefined: errors.As
 /go/src/github.com/hashicorp/go-multierror/multierror.go:117:9: undefined: errors.Is
 ```
+### Compatibility notice
+
+The following function signatures have been changed to return the
+stdlib `error` interface (as per the best practices). If your code
+relies on always having a `*Error` type then you can use `Cast` to
+convert from the stdlib `error` interface into a `*Error`.
+
+New signatures:
+```go
+func Append(err error, errs ...error) error
+
+func (g *Group) Wait() error
+```
+
+Casting example:
+```go
+var err error
+var result *multierror.Error
+result = Cast(err)
+```
 
 ## Usage
 

--- a/append.go
+++ b/append.go
@@ -8,7 +8,7 @@ package multierror
 // one level into err.
 // Any nil errors within errs will be ignored. If err is nil, a new
 // *Error will be returned.
-func Append(err error, errs ...error) *Error {
+func Append(err error, errs ...error) error {
 	switch err := err.(type) {
 	case *Error:
 		// Typed nils can reach here, so initialize if we are nil
@@ -30,7 +30,14 @@ func Append(err error, errs ...error) *Error {
 			}
 		}
 
-		return err
+		switch err.Len() {
+		case 0:
+			return nil
+		case 1:
+			return err.Errors[0]
+		default:
+			return err
+		}
 	default:
 		newErrs := make([]error, 0, len(errs)+1)
 		if err != nil {

--- a/append_test.go
+++ b/append_test.go
@@ -10,20 +10,23 @@ func TestAppend_Error(t *testing.T) {
 		Errors: []error{errors.New("foo")},
 	}
 
-	result := Append(original, errors.New("bar"))
+	err := Append(original, errors.New("bar"))
+	result := Cast(err)
 	if len(result.Errors) != 2 {
 		t.Fatalf("wrong len: %d", len(result.Errors))
 	}
 
 	original = &Error{}
-	result = Append(original, errors.New("bar"))
+	err = Append(original, errors.New("bar"))
+	result = Cast(err)
 	if len(result.Errors) != 1 {
 		t.Fatalf("wrong len: %d", len(result.Errors))
 	}
 
 	// Test when a typed nil is passed
 	var e *Error
-	result = Append(e, errors.New("baz"))
+	err = Append(e, errors.New("baz"))
+	result = Cast(err)
 	if len(result.Errors) != 1 {
 		t.Fatalf("wrong len: %d", len(result.Errors))
 	}
@@ -33,7 +36,8 @@ func TestAppend_Error(t *testing.T) {
 		Errors: []error{errors.New("foo")},
 	}
 
-	result = Append(original, Append(nil, errors.New("foo"), errors.New("bar")))
+	err = Append(original, Append(nil, errors.New("foo"), errors.New("bar")))
+	result = Cast(err)
 	if len(result.Errors) != 3 {
 		t.Fatalf("wrong len: %d", len(result.Errors))
 	}
@@ -41,7 +45,8 @@ func TestAppend_Error(t *testing.T) {
 
 func TestAppend_NilError(t *testing.T) {
 	var err error
-	result := Append(err, errors.New("bar"))
+	err = Append(err, errors.New("bar"))
+	result := Cast(err)
 	if len(result.Errors) != 1 {
 		t.Fatalf("wrong len: %d", len(result.Errors))
 	}
@@ -50,7 +55,8 @@ func TestAppend_NilError(t *testing.T) {
 func TestAppend_NilErrorArg(t *testing.T) {
 	var err error
 	var nilErr *Error
-	result := Append(err, nilErr)
+	err = Append(err, nilErr)
+	result := Cast(err)
 	if len(result.Errors) != 0 {
 		t.Fatalf("wrong len: %d", len(result.Errors))
 	}
@@ -59,7 +65,8 @@ func TestAppend_NilErrorArg(t *testing.T) {
 func TestAppend_NilErrorIfaceArg(t *testing.T) {
 	var err error
 	var nilErr error
-	result := Append(err, nilErr)
+	err = Append(err, nilErr)
+	result := Cast(err)
 	if len(result.Errors) != 0 {
 		t.Fatalf("wrong len: %d", len(result.Errors))
 	}
@@ -67,7 +74,8 @@ func TestAppend_NilErrorIfaceArg(t *testing.T) {
 
 func TestAppend_NonError(t *testing.T) {
 	original := errors.New("foo")
-	result := Append(original, errors.New("bar"))
+	err := Append(original, errors.New("bar"))
+	result := Cast(err)
 	if len(result.Errors) != 2 {
 		t.Fatalf("wrong len: %d", len(result.Errors))
 	}
@@ -75,7 +83,8 @@ func TestAppend_NonError(t *testing.T) {
 
 func TestAppend_NonError_Error(t *testing.T) {
 	original := errors.New("foo")
-	result := Append(original, Append(nil, errors.New("bar")))
+	err := Append(original, Append(nil, errors.New("bar")))
+	result := Cast(err)
 	if len(result.Errors) != 2 {
 		t.Fatalf("wrong len: %d", len(result.Errors))
 	}

--- a/cast.go
+++ b/cast.go
@@ -1,0 +1,17 @@
+package multierror
+
+// Returns any given error (including nil) as a *Error object for compatibility
+// which expects to always handle *Error rather than the stdlib error interface.
+func Cast(err error) *Error {
+	switch err := err.(type) {
+	case *Error:
+		return err
+	default:
+		if err == nil {
+			return &Error{}
+		}
+		return &Error{
+			Errors: []error{err},
+		}
+	}
+}

--- a/cast_test.go
+++ b/cast_test.go
@@ -1,0 +1,21 @@
+package multierror
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestCast_Nil(t *testing.T) {
+	const expected = "*multierror.Error{Errors:[]error(nil), ErrorFormat:(multierror.ErrorFormatFunc)(nil)}"
+	result := Cast(nil)
+	if result.GoString() != expected {
+		t.Fatalf("wrong result: %s", result.GoString())
+	}
+}
+
+func TestCast_Error(t *testing.T) {
+	result := Cast(errors.New("test message"))
+	if len(result.Errors) != 1 {
+		t.Fatalf("wrong len: %d", len(result.Errors))
+	}
+}

--- a/group.go
+++ b/group.go
@@ -6,7 +6,7 @@ import "sync"
 // coalesced.
 type Group struct {
 	mutex sync.Mutex
-	err   *Error
+	err   error
 	wg    sync.WaitGroup
 }
 
@@ -30,7 +30,7 @@ func (g *Group) Go(f func() error) {
 
 // Wait blocks until all function calls from the Go method have returned, then
 // returns the multierror.
-func (g *Group) Wait() *Error {
+func (g *Group) Wait() error {
 	g.wg.Wait()
 	g.mutex.Lock()
 	defer g.mutex.Unlock()


### PR DESCRIPTION
Thanks for an excellent library! 

I'm opening this pull request to propose a several very small changes which are intended to make the Append function _"behave as you would expect"_ (as is suggested in the README).

Changes:

- Return the standard library `error` interface from `Append` (this is a change to the function signature)
    
    Note the following advice from the [golang FAQ](https://golang.org/doc/faq#nil_error)
    > It's a good idea for functions that return errors always to use the error type in their signature (as we did above) rather than a concrete type such as *MyError, to help guarantee the error is created correctly. As an example, os.Open returns an error even though, if not nil, it's always of concrete type *os.PathError.

- Return  the standard library `error` interface from `(g *Group) Wait()` (this is a change to the function signature)

- Return `nil` from `Append` when there is no error

- Return the original error from `Append` when there is only one error (i.e. appending to nil)

- Introduce a new `Cast` method to allow older code which requires a `*multierror.Error` to be easily updated

- Change the `Group.err` field from `*Error` to `error`
