### PR TITLE
Add global default ErrorFormatFunc

### DIFF
--- a/format.go
+++ b/format.go
@@ -9,6 +9,9 @@ import (
 // turn the list of errors into a string.
 type ErrorFormatFunc func([]error) string
 
+// DefaultErrorFormatFunc is the default ErrorFormatFunc
+var DefaultErrorFormatFunc = ListFormatFunc
+
 // ListFormatFunc is a basic formatter that outputs the number of errors
 // that occurred along with a bullet point list of the errors.
 func ListFormatFunc(es []error) string {

--- a/multierror.go
+++ b/multierror.go
@@ -15,7 +15,7 @@ type Error struct {
 func (e *Error) Error() string {
 	fn := e.ErrorFormat
 	if fn == nil {
-		fn = ListFormatFunc
+		fn = DefaultErrorFormatFunc
 	}
 
 	return fn(e.Errors)


### PR DESCRIPTION
Adds the possibility to set the default ErrorFormatFunc, so a consistend error formatting can be used without the need to initialize all multierrors with ErrorFormat field