### PR TITLE
replace hashicorp/errwrap with go1.13 native error wrapping

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/hashicorp/go-multierror
 
 go 1.13
-
-require github.com/hashicorp/errwrap v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
-github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/prefix.go
+++ b/prefix.go
@@ -1,10 +1,6 @@
 package multierror
 
-import (
-	"fmt"
-
-	"github.com/hashicorp/errwrap"
-)
+import "fmt"
 
 // Prefix is a helper function that will prefix some text
 // to the given error. If the error is a multierror.Error, then
@@ -17,7 +13,7 @@ func Prefix(err error, prefix string) error {
 		return nil
 	}
 
-	format := fmt.Sprintf("%s {{err}}", prefix)
+	format := prefix + " %w"
 	switch err := err.(type) {
 	case *Error:
 		// Typed nils can reach here, so initialize if we are nil
@@ -27,11 +23,11 @@ func Prefix(err error, prefix string) error {
 
 		// Wrap each of the errors
 		for i, e := range err.Errors {
-			err.Errors[i] = errwrap.Wrapf(format, e)
+			err.Errors[i] = fmt.Errorf(format, e)
 		}
 
 		return err
 	default:
-		return errwrap.Wrapf(format, err)
+		return fmt.Errorf(format, err)
 	}
 }


### PR DESCRIPTION
The `errwrap.Wrapf()` function was deprecated in favor of native go 1.13 error
wrapping in github.com/hashicorp/errwrap v1.1.0 (https://github.com/hashicorp/errwrap/pull/9).

This updates the `Prefix()` function to use native error wrapping, which removes the dependency on github.com/hashicorp/errwrap.
