### PR TITLE
fix: handle nil pointer in Len function of Error struct

### DIFF
--- a/sort.go
+++ b/sort.go
@@ -4,7 +4,11 @@
 package multierror
 
 // Len implements sort.Interface function for length
-func (err Error) Len() int {
+func (err *Error) Len() int {
+	if err == nil {
+		return 0
+	}
+
 	return len(err.Errors)
 }
 


### PR DESCRIPTION
Similar to `*Error.ErrorOrNil`, handle `nil` values for *Error
gracefully, return a length of 0.
