### PR TITLE
refactor: the errwrap.Wrapf method has been deprecated and replaced with fmt.Errorf.

### DIFF
--- a/prefix.go
+++ b/prefix.go
@@ -3,11 +3,7 @@
 
 package multierror
 
-import (
-	"fmt"
-
-	"github.com/hashicorp/errwrap"
-)
+import "fmt"
 
 // Prefix is a helper function that will prefix some text
 // to the given error. If the error is a multierror.Error, then
@@ -20,7 +16,6 @@ func Prefix(err error, prefix string) error {
 		return nil
 	}
 
-	format := fmt.Sprintf("%s {{err}}", prefix)
 	switch err := err.(type) {
 	case *Error:
 		// Typed nils can reach here, so initialize if we are nil
@@ -28,13 +23,12 @@ func Prefix(err error, prefix string) error {
 			err = new(Error)
 		}
 
-		// Wrap each of the errors
 		for i, e := range err.Errors {
-			err.Errors[i] = errwrap.Wrapf(format, e)
+			err.Errors[i] = fmt.Errorf("%s %s", prefix, e)
 		}
 
 		return err
 	default:
-		return errwrap.Wrapf(format, err)
+		return fmt.Errorf("%s %s", prefix, err)
 	}
 }


### PR DESCRIPTION
errwrap.Wrapf has been deprecated, and fmt.Errorf is recommended.